### PR TITLE
Update error handling to problem details format

### DIFF
--- a/src/main/java/ru/infologistics/docuforce365/shell/GlobalExceptionHandler.java
+++ b/src/main/java/ru/infologistics/docuforce365/shell/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package ru.infologistics.docuforce365.shell;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import ru.infologistics.docuforce365.shell.dto.ApiRestResponse;
+import ru.infologistics.docuforce365.shell.ErrorCode;
 
 /** Handles uncaught exceptions and converts them to API error responses. */
 @Slf4j
@@ -19,16 +21,20 @@ public class GlobalExceptionHandler {
   private final MessageSource messageSource;
 
   @ExceptionHandler(Exception.class)
-  public ResponseEntity<ApiRestResponse> handleException(Exception ex, Locale locale) {
+  public ResponseEntity<ApiRestResponse> handleException(
+      Exception ex, Locale locale, HttpServletRequest request) {
     log.error("Unhandled exception", ex);
     String message = messageSource.getMessage("error.internal", null, locale);
     ApiRestResponse body = new ApiRestResponse(
-        System.currentTimeMillis(),
-        MDC.get(Coonsts.CORRELATION_ID_LOG_VAR),
+        "about:blank",
         HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(),
+        HttpStatus.INTERNAL_SERVER_ERROR.value(),
         message,
-        ErrorCode.UNSPECIFIED,
-        ex.getMessage());
+        request.getRequestURI(),
+        MDC.get(Coonsts.CORRELATION_ID_LOG_VAR),
+        ex.getMessage(),
+        System.currentTimeMillis(),
+        ErrorCode.UNSPECIFIED);
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
   }
 }

--- a/src/main/java/ru/infologistics/docuforce365/shell/dto/ApiRestResponse.java
+++ b/src/main/java/ru/infologistics/docuforce365/shell/dto/ApiRestResponse.java
@@ -4,14 +4,17 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import ru.infologistics.docuforce365.shell.ErrorCode;
 
-/** Error response structure matching the API specification. */
+/** Standardized API error response. */
 @Data
 @AllArgsConstructor
 public class ApiRestResponse {
-  private long timestamp;
+  private String type;
+  private String title;
+  private int status;
+  private String detail;
+  private String instance;
   private String correlationId;
-  private String error;
-  private String message;
-  private ErrorCode errorCode;
   private String debugMessage;
+  private long timestamp;
+  private ErrorCode errorCode;
 }


### PR DESCRIPTION
## Summary
- adapt `ApiRestResponse` to new RFC9457-style problem details
- adjust `GlobalExceptionHandler` to populate the updated fields

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a862c5198832e9f48666771eba622