### PR TITLE
Add request scope bean for correlation id

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,9 +89,11 @@
 
 ## Structure hints
 - common `Coonsts` class for vars, mentioned below
+- request-scoped bean `RequestScopeBean` to hold the correlation id per request
 - single LoggingFilter (OncePerRequestFilter):
   - gets correlationId from header `HEADER_CORRELATION_ID = "Correlation-Id"` or generates a random one, corresponding the specified pattern
   - correlationId is added to MDC under `CORRELATION_ID_LOG_VAR = "correlationId"` (implement in constants) - this addition should be implemented in all child threads
+  - correlationId is saved to `RequestScopeBean` so other components can access it
   - logs method and url on DEBUG level before processing; headers on TRACE
   - logs method, url, status and execution time in millis on DEBUG after processing
-- single exception handler which returns standardized error structure (refer to spec) with localized message, taken from *.properties file and correlation id from MDC
+- single exception handler which returns standardized error structure (refer to spec) with localized message, taken from *.properties file and correlation id from `RequestScopeBean`

--- a/src/main/java/ru/infologistics/docuforce365/shell/GlobalExceptionHandler.java
+++ b/src/main/java/ru/infologistics/docuforce365/shell/GlobalExceptionHandler.java
@@ -4,7 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.MDC;
+import ru.infologistics.docuforce365.shell.RequestScopeBean;
 import org.springframework.context.MessageSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +19,7 @@ import ru.infologistics.docuforce365.shell.ErrorCode;
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
   private final MessageSource messageSource;
+  private final RequestScopeBean requestScopeBean;
 
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ApiRestResponse> handleException(
@@ -31,7 +32,7 @@ public class GlobalExceptionHandler {
         HttpStatus.INTERNAL_SERVER_ERROR.value(),
         message,
         request.getRequestURI(),
-        MDC.get(Coonsts.CORRELATION_ID_LOG_VAR),
+        requestScopeBean.getCorrelationId(),
         ex.getMessage(),
         System.currentTimeMillis(),
         ErrorCode.UNSPECIFIED);

--- a/src/main/java/ru/infologistics/docuforce365/shell/LoggingFilter.java
+++ b/src/main/java/ru/infologistics/docuforce365/shell/LoggingFilter.java
@@ -10,10 +10,12 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import ru.infologistics.docuforce365.shell.RequestScopeBean;
 
 /**
  * Filter that enriches requests with correlation id and puts it in MDC
@@ -21,7 +23,9 @@ import org.springframework.web.filter.OncePerRequestFilter;
  */
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class LoggingFilter extends OncePerRequestFilter {
+  private final RequestScopeBean requestScopeBean;
   private static final char[] ALPHANUMERIC =
       "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".toCharArray();
   private static final SecureRandom RANDOM = new SecureRandom();
@@ -42,6 +46,7 @@ public class LoggingFilter extends OncePerRequestFilter {
       correlationId = generateCorrelationId();
     }
     MDC.put(Coonsts.CORRELATION_ID_LOG_VAR, correlationId);
+    requestScopeBean.setCorrelationId(correlationId);
     response.setHeader(Coonsts.HEADER_CORRELATION_ID, correlationId);
     Map<String, String> headers = Collections.list(request.getHeaderNames())
         .stream()

--- a/src/main/java/ru/infologistics/docuforce365/shell/RequestScopeBean.java
+++ b/src/main/java/ru/infologistics/docuforce365/shell/RequestScopeBean.java
@@ -1,0 +1,16 @@
+package ru.infologistics.docuforce365.shell;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+/** Holds request-specific context like correlation id. */
+@Getter
+@Setter
+@Component
+@RequestScope
+public class RequestScopeBean {
+  private String correlationId;
+}
+


### PR DESCRIPTION
## Summary
- create `RequestScopeBean` that holds correlation id per request
- inject this bean in `LoggingFilter` and `GlobalExceptionHandler`
- store correlation id from filter and read it back in the exception handler

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a99f90774832eabe695f9299d6f29